### PR TITLE
Added Open Graph meta tags.

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,6 +5,12 @@
 
   <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
+  <meta property="og:site_name" content="{{ site.title }}">
+  <meta property="og:url" content="{{ site.url }}{{ page.url | replace: 'index.html', '' }}">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}">
+  <meta property="og:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
+  <meta property="og:image" content="{{ site.url }}/assets/images/manhattanjs-logo.png">
   <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link href='https://fonts.googleapis.com/css?family=Montserrat:400,700' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
Added og meta tags so when the url is added to anything that uses Open Graph (Facebook, Reddit, Slack, etc.), it will look all purdy with the ManhattanJS logo and whatnot. I would suggest creating an open graph friendly image. Here's a [nifty guide] (http://www.h3xed.com/web-and-internet/how-to-use-og-image-meta-tag-facebook-reddit). I'm using `\assets\images\manhattanjs-logo.png` as a placeholder. It might look okay.