### PR TITLE
August 2016 afterparty

### DIFF
--- a/_includes/speakers/speaker-list-2016-08.html
+++ b/_includes/speakers/speaker-list-2016-08.html
@@ -27,7 +27,7 @@
       <time>7:30pm</time>
     </div>
   </div>
-  
+
   <div class="timeline-block">
     <span class="timeline-dot"></span>
 
@@ -95,12 +95,15 @@
     <div class="timeline-content">
       <p class="event-info-headline">Closing + Afterparty</p>
       <p class="speaker-sub-info">Post Event Shenanigans</p>
-      <p class="speaker-talk-title">TDB</p>
+      <p class="speaker-talk-title">
+        <a href="https://www.google.com/maps/place/The+Irish+American+Pub/@40.7099632,-74.0093276,18z/data=!3m1!4b1!4m5!3m4!1s0x0:0x2b30d6d3b1ce328f!8m2!3d40.7099633!4d-74.0087248",
+          target="_blank" class="speaker-info">
+          <p>  The Irish American Pub</p>
+        </a>
+      </p>
       <time>9:20pm</time>
     </div>
   </div>
 </section>
 
 {% include sponsors/august-2016.html %}
-
-


### PR DESCRIPTION
Adds  the August 2016 afterparty destination and  Google maps link

This links to ```The Irish American Pub``` and location used in the past after we were hosted at Namely