### PR TITLE
feat(mobile) Add mobile styles

### DIFF
--- a/_sass/_about.scss
+++ b/_sass/_about.scss
@@ -33,7 +33,7 @@
     text-transform: uppercase;
     width: 350px;
   	text-shadow: 0 2px 2px rgba(0, 0, 0, .25);
-
+  	max-width: 100%;
 
     &:hover {
     	background-color: $hover-red;
@@ -42,6 +42,6 @@
   }
 
   @include breakpoint(medium) {
-  	padding: 50px;
+  	padding: 50px 18px;
   }
 }

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -75,6 +75,11 @@ img, embed, object, video, svg {
   display: flex;
   justify-content: center;
   align-items: center;
+
+  @include breakpoint(medium) {
+    padding: 9px 9px 18px;
+    display: block;
+  }
 }
 
 .event-background {
@@ -99,15 +104,33 @@ img, embed, object, video, svg {
   background-size: 300px;
   color: #8d9296;
   box-shadow: 0 37px 35px rgba(0,0,0, .3);
+
+  @include breakpoint(medium) {
+    background-position: top left;
+    background-size: 100%;
+    display: block;
+    height: auto;
+    flex: none;
+    width: 100%;
+    padding-top: 167%;
+  }
 }
 
 .wrapper {
   min-width: 450px;
   position: relative;
+
+  @include breakpoint(medium) {
+    min-width: 0;
+  }
 }
 
 .top {
   padding: 57px 50px 65px 60px;
+
+  @include breakpoint(medium) {
+    padding: 18px 18px 124px;    
+  }
 }
 
 header {
@@ -129,6 +152,10 @@ header {
     text-transform: uppercase;
     text-align: center;
     margin: 0;
+
+    @include breakpoint(medium) {
+      margin: 12px 12px 0 0;
+    }
 
     b {
       line-height: 1;
@@ -175,7 +202,10 @@ ul#countdown {
     text-align: center;
     &:not(:first-of-type)  {
       margin-left: 40px;
-    }
+      @include breakpoint(medium) {
+        margin-left: 18px;
+      }
+    }  
     span {
       width: 100%;
       font-size: 26px;

--- a/_sass/_speak.scss
+++ b/_sass/_speak.scss
@@ -5,6 +5,10 @@
   max-width: 960px;
   margin: 0 auto;
 
+  @include breakpoint(small) {
+    width: 80%;
+  }
+
   &::after {
     content: '';
     display: table;
@@ -107,6 +111,12 @@
     padding: .8em 0;
     opacity: .7;
     color: rgba(255, 255, 255, 0.79);
+
+    @include breakpoint(small) {
+      color: $light-gray;
+      display: block;
+      float: none;
+    }
   }
 
   &:before {

--- a/_sass/_sponsorship.scss
+++ b/_sass/_sponsorship.scss
@@ -5,6 +5,10 @@
   max-width: 700px;
   padding: 0 1em 2em;
 
+  @include breakpoint(medium) {
+    max-width: 100%;
+  }
+
   h1 {
     font-family: $header-font;
     line-height: 1.2em;
@@ -33,7 +37,7 @@
   padding-left: 0px;
   margin: 0 auto;
   margin-bottom: 1.25em;
-  width: 700px;
+  max-width: 700px;
   text-align: center;
 }
 
@@ -48,8 +52,8 @@
 
   @include breakpoint(small) {
     display: block;
-    margin: 1em 0.75em;
-    width: 300px;
+    margin: 1em auto;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
- Use display block to stack
- Reduce padding

This is a random PR but I noticed that the mobile site was a little hard to read, so I spent an hour stacking the content. I followed your desktop-first approach and used the media query mixins. 

One nice thing is the building plus the date looks like an exclamation mark!

## Current
<img src="https://user-images.githubusercontent.com/3998604/32410361-75c65070-c194-11e7-9779-075bacb14c72.png" width="49%" />

## Update
<div style="display: flex">
<img src="https://user-images.githubusercontent.com/3998604/32410333-eaac76c2-c193-11e7-84ba-b822eb735813.png" width="49%" />
<img src="https://user-images.githubusercontent.com/3998604/32410332-eaa0ea1e-c193-11e7-9af4-0375dc4091f8.png" width="49%" />
<img src="https://user-images.githubusercontent.com/3998604/32410352-55c388b0-c194-11e7-8563-1a6079d9c89b.png" width="49%" />
<img src="https://user-images.githubusercontent.com/3998604/32410329-ea7d7340-c193-11e7-828b-38a06edf7924.png" width="49%" />
<img src="https://user-images.githubusercontent.com/3998604/32410331-ea965e46-c193-11e7-9189-40d4a7099221.png" width="49%" />
<img src="https://user-images.githubusercontent.com/3998604/32410330-ea8c71f6-c193-11e7-8b44-22a563a14359.png" width="49%" />
</div>


